### PR TITLE
fix: load watcher module at runtime

### DIFF
--- a/src/kernel/core/custom-process.ts
+++ b/src/kernel/core/custom-process.ts
@@ -1,4 +1,11 @@
-import { node_process_watcher } from 'node-process-watcher'
+// Dynamically require the native module at runtime to avoid bundler issues.
+// Using `eval('require')` prevents Vite's build step from attempting to
+// process the `.node` binary inside `node-process-watcher`, which previously
+// caused the development build to fail with a "No loader is configured for
+// '.node' files" error.
+const { node_process_watcher } = (eval('require') as typeof require)(
+  'node-process-watcher'
+) as typeof import('node-process-watcher')
 
 import { ElectronAPIEventKeys } from '../../config/constants/main-process'
 


### PR DESCRIPTION
## Summary
- dynamically require node-process-watcher to avoid .node loader errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm start` *(fails: node-gyp failed to rebuild 'node-process-watcher')*


------
https://chatgpt.com/codex/tasks/task_e_6892e86fd5d0832aba9da6497eb87623