### PR TITLE
fix: load watcher module at runtime

### DIFF
--- a/src/kernel/core/custom-process.ts
+++ b/src/kernel/core/custom-process.ts
@@ -1,8 +1,15 @@
-import { node_process_watcher } from 'node-process-watcher'
-
+// Dynamically require the native module at runtime to avoid bundler issues.
+// Using `createRequire` prevents Vite's build step from attempting to process
+// the `.node` binary inside `node-process-watcher`, which previously caused the
+// development build to fail with a "No loader is configured for '.node' files"
+// error.
+import { createRequire } from 'node:module'
 import { ElectronAPIEventKeys } from '../../config/constants/main-process'
-
 import { MainWindow } from '../startup/windows/main'
+
+const { node_process_watcher } = createRequire(import.meta.url)(
+  'node-process-watcher'
+) as typeof import('node-process-watcher')
 
 export class CustomProcess {
   private static id: number | null = null


### PR DESCRIPTION
## Summary
- dynamically load node-process-watcher using Node's createRequire to avoid bundler .node loader errors without relying on eval

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm start` *(fails: node-gyp failed to rebuild 'node-process-watcher')*


------
https://chatgpt.com/codex/tasks/task_e_6892e86fd5d0832aba9da6497eb87623