### PR TITLE
feat(account-management): add public profile query page

### DIFF
--- a/src/components/menu/sidebar.tsx
+++ b/src/components/menu/sidebar.tsx
@@ -268,6 +268,21 @@ export function SidebarMenu({
                       </Link>
                     </li>
                   )}
+                  {getMenuOptionVisibility('publicProfile') && (
+                    <li className="item">
+                      <Link
+                        to="/account-management/public-profile"
+                        className={currentClassNameHover}
+                        activeProps={{
+                          className: cn(activeClassName),
+                        }}
+                        onClick={goToPage}
+                        onAuxClick={whatIsThis()}
+                      >
+                        {t('account-management.options.public-profile')}
+                      </Link>
+                    </li>
+                  )}
                   {getMenuOptionVisibility('vbucksInformation') && (
                     <li className="item">
                       <Link

--- a/src/lib/validations/schemas/settings.ts
+++ b/src/lib/validations/schemas/settings.ts
@@ -60,6 +60,7 @@ export const customizableMenuSettingsSchema = z
 
       accountManagement: z.boolean().default(true),
       accountStats: z.boolean().default(true),
+    publicProfile: z.boolean().default(true),
       vbucksInformation: z.boolean().default(true),
       redeemCodes: z.boolean().default(true),
       devicesAuth: z.boolean().default(true),

--- a/src/locales/en-US/account-management/public-profile.json
+++ b/src/locales/en-US/account-management/public-profile.json
@@ -1,0 +1,21 @@
+{
+  "description": "Search a Fortnite player and fetch their public STW profile.",
+  "account": "Account selected: {{name}}",
+  "form": {
+    "label": "Player display name",
+    "placeholder": "Example: Ninja",
+    "submit-button": "Query Public Profile"
+  },
+  "results": {
+    "title": "Filtered public profile data",
+    "display-name": "Display Name",
+    "account-id": "Account ID",
+    "homebase-name": "Homebase Name",
+    "commander-level": "Commander Level",
+    "collection-book-level": "Collection Book Level",
+    "zones-completed": "Zones Completed",
+    "total-items": "Total Items",
+    "last-updated": "Last Updated"
+  },
+  "error": "Failed to retrieve public profile"
+}

--- a/src/locales/en-US/sidebar.json
+++ b/src/locales/en-US/sidebar.json
@@ -20,6 +20,7 @@
     "title": "Account Management",
     "options": {
       "stats": "Stats",
+      "public-profile": "Public Profile",
       "vbucks-information": "V-Bucks Information",
       "redeem-codes": "Redeem Codes",
       "devices-auth": "Devices Auth",

--- a/src/locales/es-419/account-management/public-profile.json
+++ b/src/locales/es-419/account-management/public-profile.json
@@ -1,0 +1,21 @@
+{
+  "description": "Search a Fortnite player and fetch their public STW profile.",
+  "account": "Account selected: {{name}}",
+  "form": {
+    "label": "Player display name",
+    "placeholder": "Example: Ninja",
+    "submit-button": "Query Public Profile"
+  },
+  "results": {
+    "title": "Filtered public profile data",
+    "display-name": "Display Name",
+    "account-id": "Account ID",
+    "homebase-name": "Homebase Name",
+    "commander-level": "Commander Level",
+    "collection-book-level": "Collection Book Level",
+    "zones-completed": "Zones Completed",
+    "total-items": "Total Items",
+    "last-updated": "Last Updated"
+  },
+  "error": "Failed to retrieve public profile"
+}

--- a/src/locales/es-419/sidebar.json
+++ b/src/locales/es-419/sidebar.json
@@ -20,6 +20,7 @@
     "title": "Administrar Cuenta",
     "options": {
       "stats": "Estadísticas",
+      "public-profile": "Public Profile",
       "vbucks-information": "Información de V-Bucks",
       "redeem-codes": "Reclamar Códigos",
       "devices-auth": "Autenticación de Dispositivos",

--- a/src/locales/pl-PL/account-management/public-profile.json
+++ b/src/locales/pl-PL/account-management/public-profile.json
@@ -1,0 +1,21 @@
+{
+  "description": "Search a Fortnite player and fetch their public STW profile.",
+  "account": "Account selected: {{name}}",
+  "form": {
+    "label": "Player display name",
+    "placeholder": "Example: Ninja",
+    "submit-button": "Query Public Profile"
+  },
+  "results": {
+    "title": "Filtered public profile data",
+    "display-name": "Display Name",
+    "account-id": "Account ID",
+    "homebase-name": "Homebase Name",
+    "commander-level": "Commander Level",
+    "collection-book-level": "Collection Book Level",
+    "zones-completed": "Zones Completed",
+    "total-items": "Total Items",
+    "last-updated": "Last Updated"
+  },
+  "error": "Failed to retrieve public profile"
+}

--- a/src/locales/pl-PL/sidebar.json
+++ b/src/locales/pl-PL/sidebar.json
@@ -20,6 +20,7 @@
     "title": "Zarządzanie kontem",
     "options": {
       "stats": "Statystyki",
+      "public-profile": "Public Profile",
       "vbucks-information": "Informacje o V-Dolcach",
       "redeem-codes": "Zrealizuj kody",
       "devices-auth": "Urządzenia autoryzowane",

--- a/src/locales/pt-BR/account-management/public-profile.json
+++ b/src/locales/pt-BR/account-management/public-profile.json
@@ -1,0 +1,21 @@
+{
+  "description": "Search a Fortnite player and fetch their public STW profile.",
+  "account": "Account selected: {{name}}",
+  "form": {
+    "label": "Player display name",
+    "placeholder": "Example: Ninja",
+    "submit-button": "Query Public Profile"
+  },
+  "results": {
+    "title": "Filtered public profile data",
+    "display-name": "Display Name",
+    "account-id": "Account ID",
+    "homebase-name": "Homebase Name",
+    "commander-level": "Commander Level",
+    "collection-book-level": "Collection Book Level",
+    "zones-completed": "Zones Completed",
+    "total-items": "Total Items",
+    "last-updated": "Last Updated"
+  },
+  "error": "Failed to retrieve public profile"
+}

--- a/src/locales/pt-BR/sidebar.json
+++ b/src/locales/pt-BR/sidebar.json
@@ -20,6 +20,7 @@
     "title": "Gerenciamento de Conta",
     "options": {
       "stats": "Estatísticas",
+      "public-profile": "Public Profile",
       "vbucks-information": "Informações de V-Bucks",
       "redeem-codes": "Resgatar Códigos",
       "devices-auth": "Autenticação de Dispositivos",

--- a/src/locales/resources.ts
+++ b/src/locales/resources.ts
@@ -18,6 +18,7 @@ import enUS_stwOperations_XPBoosts from './en-US/stw-operations/xpboosts.json'
 import enUS_stwOperations_Llamas from './en-US/stw-operations/llamas.json'
 import enUS_stwOperations_Unlock from './en-US/stw-operations/unlock.json'
 import enUS_accountManagement_Stats from './en-US/account-management/stats.json'
+import enUS_accountManagement_PublicProfile from './en-US/account-management/public-profile.json'
 import enUS_accountManagement_VBucksInformation from './en-US/account-management/vbucks-information.json'
 import enUS_accountManagement_EULA from './en-US/account-management/eula.json'
 import enUS_accountManagement_RedeemCodes from './en-US/account-management/redeem-codes.json'
@@ -50,6 +51,7 @@ const enUS = {
     },
     'account-management': {
       stats: enUS_accountManagement_Stats,
+      'public-profile': enUS_accountManagement_PublicProfile,
       'vbucks-information': enUS_accountManagement_VBucksInformation,
       'redeem-codes': enUS_accountManagement_RedeemCodes,
       'devices-auth': enUS_accountManagement_DevicesAuth,
@@ -87,6 +89,7 @@ import es419_stwOperations_XPBoosts from './es-419/stw-operations/xpboosts.json'
 import es419_stwOperations_Llamas from './es-419/stw-operations/llamas.json'
 import es419_stwOperations_Unlock from './es-419/stw-operations/unlock.json'
 import es419_accountManagement_Stats from './es-419/account-management/stats.json'
+import es419_accountManagement_PublicProfile from './es-419/account-management/public-profile.json'
 import es419_accountManagement_VBucksInformation from './es-419/account-management/vbucks-information.json'
 import es419_accountManagement_EULA from './es-419/account-management/eula.json'
 import es419_accountManagement_RedeemCodes from './es-419/account-management/redeem-codes.json'
@@ -119,6 +122,7 @@ const es419 = {
     },
     'account-management': {
       stats: es419_accountManagement_Stats,
+      'public-profile': es419_accountManagement_PublicProfile,
       'vbucks-information': es419_accountManagement_VBucksInformation,
       'redeem-codes': es419_accountManagement_RedeemCodes,
       'devices-auth': es419_accountManagement_DevicesAuth,
@@ -156,6 +160,7 @@ import zhCN_stwOperations_XPBoosts from './zh-CN/stw-operations/xpboosts.json'
 import zhCN_stwOperations_Llamas from './zh-CN/stw-operations/llamas.json'
 import zhCN_stwOperations_Unlock from './zh-CN/stw-operations/unlock.json'
 import zhCN_accountManagement_Stats from './zh-CN/account-management/stats.json'
+import zhCN_accountManagement_PublicProfile from './zh-CN/account-management/public-profile.json'
 import zhCN_accountManagement_VBucksInformation from './zh-CN/account-management/vbucks-information.json'
 import zhCN_accountManagement_EULA from './zh-CN/account-management/eula.json'
 import zhCN_accountManagement_RedeemCodes from './zh-CN/account-management/redeem-codes.json'
@@ -188,6 +193,7 @@ const zhCN = {
     },
     'account-management': {
       stats: zhCN_accountManagement_Stats,
+      'public-profile': zhCN_accountManagement_PublicProfile,
       'vbucks-information': zhCN_accountManagement_VBucksInformation,
       'redeem-codes': zhCN_accountManagement_RedeemCodes,
       'devices-auth': zhCN_accountManagement_DevicesAuth,
@@ -225,6 +231,7 @@ import ruRU_stwOperations_XPBoosts from './ru-RU/stw-operations/xpboosts.json'
 import ruRU_stwOperations_Llamas from './ru-RU/stw-operations/llamas.json'
 import ruRU_stwOperations_Unlock from './ru-RU/stw-operations/unlock.json'
 import ruRU_accountManagement_Stats from './ru-RU/account-management/stats.json'
+import ruRU_accountManagement_PublicProfile from './ru-RU/account-management/public-profile.json'
 import ruRU_accountManagement_VBucksInformation from './ru-RU/account-management/vbucks-information.json'
 import ruRU_accountManagement_EULA from './ru-RU/account-management/eula.json'
 import ruRU_accountManagement_RedeemCodes from './ru-RU/account-management/redeem-codes.json'
@@ -257,6 +264,7 @@ const ruRU = {
     },
     'account-management': {
       stats: ruRU_accountManagement_Stats,
+      'public-profile': ruRU_accountManagement_PublicProfile,
       'vbucks-information': ruRU_accountManagement_VBucksInformation,
       'redeem-codes': ruRU_accountManagement_RedeemCodes,
       'devices-auth': ruRU_accountManagement_DevicesAuth,
@@ -294,6 +302,7 @@ import ptBR_stwOperations_XPBoosts from './pt-BR/stw-operations/xpboosts.json'
 import ptBR_stwOperations_Llamas from './pt-BR/stw-operations/llamas.json'
 import ptBR_stwOperations_Unlock from './pt-BR/stw-operations/unlock.json'
 import ptBR_accountManagement_Stats from './pt-BR/account-management/stats.json'
+import ptBR_accountManagement_PublicProfile from './pt-BR/account-management/public-profile.json'
 import ptBR_accountManagement_VBucksInformation from './pt-BR/account-management/vbucks-information.json'
 import ptBR_accountManagement_EULA from './pt-BR/account-management/eula.json'
 import ptBR_accountManagement_RedeemCodes from './pt-BR/account-management/redeem-codes.json'
@@ -326,6 +335,7 @@ const ptBR = {
     },
     'account-management': {
       stats: ptBR_accountManagement_Stats,
+      'public-profile': ptBR_accountManagement_PublicProfile,
       'vbucks-information': ptBR_accountManagement_VBucksInformation,
       'redeem-codes': ptBR_accountManagement_RedeemCodes,
       'devices-auth': ptBR_accountManagement_DevicesAuth,
@@ -363,6 +373,7 @@ import plPL_stwOperations_XPBoosts from './pl-PL/stw-operations/xpboosts.json'
 import plPL_stwOperations_Llamas from './pl-PL/stw-operations/llamas.json'
 import plPL_stwOperations_Unlock from './pl-PL/stw-operations/unlock.json'
 import plPL_accountManagement_Stats from './pl-PL/account-management/stats.json'
+import plPL_accountManagement_PublicProfile from './pl-PL/account-management/public-profile.json'
 import plPL_accountManagement_VBucksInformation from './pl-PL/account-management/vbucks-information.json'
 import plPL_accountManagement_EULA from './pl-PL/account-management/eula.json'
 import plPL_accountManagement_RedeemCodes from './pl-PL/account-management/redeem-codes.json'
@@ -395,6 +406,7 @@ const plPL = {
     },
     'account-management': {
       stats: plPL_accountManagement_Stats,
+      'public-profile': plPL_accountManagement_PublicProfile,
       'vbucks-information': plPL_accountManagement_VBucksInformation,
       'redeem-codes': plPL_accountManagement_RedeemCodes,
       'devices-auth': plPL_accountManagement_DevicesAuth,

--- a/src/locales/ru-RU/account-management/public-profile.json
+++ b/src/locales/ru-RU/account-management/public-profile.json
@@ -1,0 +1,21 @@
+{
+  "description": "Search a Fortnite player and fetch their public STW profile.",
+  "account": "Account selected: {{name}}",
+  "form": {
+    "label": "Player display name",
+    "placeholder": "Example: Ninja",
+    "submit-button": "Query Public Profile"
+  },
+  "results": {
+    "title": "Filtered public profile data",
+    "display-name": "Display Name",
+    "account-id": "Account ID",
+    "homebase-name": "Homebase Name",
+    "commander-level": "Commander Level",
+    "collection-book-level": "Collection Book Level",
+    "zones-completed": "Zones Completed",
+    "total-items": "Total Items",
+    "last-updated": "Last Updated"
+  },
+  "error": "Failed to retrieve public profile"
+}

--- a/src/locales/ru-RU/sidebar.json
+++ b/src/locales/ru-RU/sidebar.json
@@ -20,6 +20,7 @@
     "title": "Управление Аккаунтом",
     "options": {
       "stats": "Статистика",
+      "public-profile": "Public Profile",
       "vbucks-information": "Информацию о В-баксах",
       "redeem-codes": "Активация Кодов",
       "devices-auth": "Аутентификация Устройств",

--- a/src/locales/zh-CN/account-management/public-profile.json
+++ b/src/locales/zh-CN/account-management/public-profile.json
@@ -1,0 +1,21 @@
+{
+  "description": "Search a Fortnite player and fetch their public STW profile.",
+  "account": "Account selected: {{name}}",
+  "form": {
+    "label": "Player display name",
+    "placeholder": "Example: Ninja",
+    "submit-button": "Query Public Profile"
+  },
+  "results": {
+    "title": "Filtered public profile data",
+    "display-name": "Display Name",
+    "account-id": "Account ID",
+    "homebase-name": "Homebase Name",
+    "commander-level": "Commander Level",
+    "collection-book-level": "Collection Book Level",
+    "zones-completed": "Zones Completed",
+    "total-items": "Total Items",
+    "last-updated": "Last Updated"
+  },
+  "error": "Failed to retrieve public profile"
+}

--- a/src/locales/zh-CN/sidebar.json
+++ b/src/locales/zh-CN/sidebar.json
@@ -20,6 +20,7 @@
     "title": "账户管理",
     "options": {
       "stats": "统计",
+      "public-profile": "Public Profile",
       "vbucks-information": "V币信息",
       "redeem-codes": "兑换码",
       "devices-auth": "设备授权",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as AccountManagementRedeemCodesRouteImport } from './routes/accou
 import { Route as AccountManagementEulaRouteImport } from './routes/account-management/eula/route'
 import { Route as AccountManagementEpicGamesSettingsRouteImport } from './routes/account-management/epic-games-settings/route'
 import { Route as AccountManagementDevicesAuthRouteImport } from './routes/account-management/devices-auth/route'
+import { Route as AccountManagementPublicProfileRouteImport } from './routes/account-management/public-profile/route'
 import { Route as AccountsAddTypeImport } from './routes/accounts/add/$type'
 
 // Create/Update Routes
@@ -151,6 +152,12 @@ const AccountManagementDevicesAuthRouteRoute =
     getParentRoute: () => rootRoute,
   } as any)
 
+const AccountManagementPublicProfileRouteRoute =
+  AccountManagementPublicProfileRouteImport.update({
+    path: '/account-management/public-profile',
+    getParentRoute: () => rootRoute,
+  } as any)
+
 const AccountsAddTypeRoute = AccountsAddTypeImport.update({
   path: '/accounts/add/$type',
   getParentRoute: () => rootRoute,
@@ -182,6 +189,10 @@ declare module '@tanstack/react-router' {
     }
     '/account-management/redeem-codes': {
       preLoaderRoute: typeof AccountManagementRedeemCodesRouteImport
+      parentRoute: typeof rootRoute
+    }
+    '/account-management/public-profile': {
+      preLoaderRoute: typeof AccountManagementPublicProfileRouteImport
       parentRoute: typeof rootRoute
     }
     '/account-management/stats': {
@@ -256,6 +267,7 @@ export const routeTree = rootRoute.addChildren([
   AccountManagementEpicGamesSettingsRouteRoute,
   AccountManagementEulaRouteRoute,
   AccountManagementRedeemCodesRouteRoute,
+  AccountManagementPublicProfileRouteRoute,
   AccountManagementStatsRouteRoute,
   AccountManagementVbucksInformationRouteRoute,
   AccountsRemoveRouteRoute,

--- a/src/routes/account-management/public-profile/route.tsx
+++ b/src/routes/account-management/public-profile/route.tsx
@@ -1,0 +1,217 @@
+import { UpdateIcon } from '@radix-ui/react-icons'
+import { createRoute } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+import { useMemo, useState } from 'react'
+
+import { Route as RootRoute } from '../../__root'
+
+import { HomeBreadcrumb } from '../../../components/navigations/breadcrumb/home'
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '../../../components/ui/breadcrumb'
+import { Button } from '../../../components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+} from '../../../components/ui/card'
+import { Input } from '../../../components/ui/input'
+import { Label } from '../../../components/ui/label'
+
+import { useGetSelectedAccount } from '../../../hooks/accounts'
+
+import { parseCustomDisplayName } from '../../../lib/utils'
+import { toast } from '../../../lib/notifications'
+import { findUserByDisplayName } from '../../../services/endpoints/lookup'
+import { getQueryPublicProfile } from '../../../services/endpoints/mcp'
+
+export const Route = createRoute({
+  getParentRoute: () => RootRoute,
+  path: '/account-management/public-profile',
+  component: () => {
+    const { t } = useTranslation(['sidebar'], {
+      keyPrefix: 'account-management',
+    })
+
+    return (
+      <>
+        <Breadcrumb>
+          <BreadcrumbList>
+            <HomeBreadcrumb />
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>{t('title')}</BreadcrumbPage>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>{t('options.public-profile')}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+        <Content />
+      </>
+    )
+  },
+})
+
+function Content() {
+  const { t } = useTranslation(['account-management', 'general'])
+  const { selected } = useGetSelectedAccount()
+
+  const [displayName, setDisplayName] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [data, setData] = useState<null | {
+    displayName: string
+    accountId: string
+    homebaseName: string
+    commanderLevel: number
+    zonesCompleted: number
+    collectionBookLevel: number
+    items: number
+    lastUpdated: string
+  }>(null)
+
+  const isDisabled =
+    isSubmitting || !selected?.accessToken || displayName.trim().length <= 0
+
+  const accountName = useMemo(
+    () =>
+      selected
+        ? parseCustomDisplayName(selected)
+        : t('unknown', { ns: 'general' }),
+    [selected, t]
+  )
+
+  const handleSubmit = async () => {
+    if (isDisabled || !selected?.accessToken) {
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const lookup = await findUserByDisplayName({
+        accessToken: selected.accessToken,
+        displayName: displayName.trim(),
+      })
+
+      const profile = await getQueryPublicProfile({
+        accessToken: selected.accessToken,
+        accountId: lookup.data.id,
+      })
+
+      const currentProfile = profile.data.profileChanges?.[0]?.profile
+      const attrs = currentProfile?.stats?.attributes
+      const homebaseName = (attrs as { homebase_name?: string } | undefined)?.homebase_name
+      const gameplay = attrs?.gameplay_stats ?? []
+      const zonesCompleted =
+        gameplay.find((item) => item.statName === 'zonescompleted')
+          ?.statValue ?? 0
+
+      setData({
+        displayName: lookup.data.displayName,
+        accountId: lookup.data.id,
+        homebaseName: homebaseName ?? '-',
+        commanderLevel: attrs?.level ?? 0,
+        zonesCompleted,
+        collectionBookLevel: attrs?.collection_book?.maxBookXpLevelAchieved ?? 0,
+        items: Object.keys(currentProfile?.items ?? {}).length,
+        lastUpdated: currentProfile?.updated ?? '-',
+      })
+    } catch (error) {
+      setData(null)
+      toast.error(t('public-profile.error'))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-grow">
+      <div className="flex items-center justify-center w-full">
+        <div className="max-w-lg space-y-4 w-full">
+          <Card>
+            <CardHeader className="border-b">
+              <CardDescription>{t('public-profile.description')}</CardDescription>
+              <CardDescription>
+                {t('public-profile.account', { name: accountName })}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="pt-6 space-y-3">
+              <Label htmlFor="public-profile-display-name">
+                {t('public-profile.form.label')}
+              </Label>
+              <Input
+                id="public-profile-display-name"
+                placeholder={t('public-profile.form.placeholder')}
+                value={displayName}
+                onChange={(event) => setDisplayName(event.target.value)}
+              />
+
+              <Button
+                className="w-full"
+                disabled={isDisabled}
+                onClick={handleSubmit}
+              >
+                {isSubmitting ? (
+                  <UpdateIcon className="animate-spin" />
+                ) : (
+                  t('public-profile.form.submit-button')
+                )}
+              </Button>
+            </CardContent>
+          </Card>
+
+          {data && (
+            <Card>
+              <CardHeader className="border-b">
+                <CardDescription>{t('public-profile.results.title')}</CardDescription>
+              </CardHeader>
+              <CardContent className="pt-6 text-sm">
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>
+                    {t('public-profile.results.display-name')}:{' '}
+                    <span className="font-bold">{data.displayName}</span>
+                  </li>
+                  <li>
+                    {t('public-profile.results.account-id')}:{' '}
+                    <span className="font-bold break-all">{data.accountId}</span>
+                  </li>
+                  <li>
+                    {t('public-profile.results.homebase-name')}:{' '}
+                    <span className="font-bold">{data.homebaseName}</span>
+                  </li>
+                  <li>
+                    {t('public-profile.results.commander-level')}:{' '}
+                    <span className="font-bold">{data.commanderLevel}</span>
+                  </li>
+                  <li>
+                    {t('public-profile.results.collection-book-level')}:{' '}
+                    <span className="font-bold">{data.collectionBookLevel}</span>
+                  </li>
+                  <li>
+                    {t('public-profile.results.zones-completed')}:{' '}
+                    <span className="font-bold">{data.zonesCompleted}</span>
+                  </li>
+                  <li>
+                    {t('public-profile.results.total-items')}:{' '}
+                    <span className="font-bold">{data.items}</span>
+                  </li>
+                  <li>
+                    {t('public-profile.results.last-updated')}:{' '}
+                    <span className="font-bold">{data.lastUpdated}</span>
+                  </li>
+                </ul>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/routes/settings/-customizable-menu/-index.tsx
+++ b/src/routes/settings/-customizable-menu/-index.tsx
@@ -213,6 +213,19 @@ function AccountManagementSection() {
           <div className="item">
             <Label
               className="title"
+              htmlFor="public-profile"
+            >
+              {t('account-management.options.public-profile')}
+            </Label>
+            <Switch
+              id="public-profile"
+              checked={getMenuOptionVisibility('publicProfile')}
+              onCheckedChange={updateMenuOption('publicProfile')}
+            />
+          </div>
+          <div className="item">
+            <Label
+              className="title"
               htmlFor="vbucks-information"
             >
             {t('account-management.options.vbucks-information')}

--- a/src/state/settings/customizable-menu.ts
+++ b/src/state/settings/customizable-menu.ts
@@ -36,6 +36,7 @@ export const customizableMenuSettingsRelations: Record<
   ],
     accountManagement: [
       'accountStats',
+      'publicProfile',
       'vbucksInformation',
       'redeemCodes',
       'devicesAuth',


### PR DESCRIPTION
### Motivation
- Provide a simple way to query a Fortnite player's public STW profile by display name and show filtered, relevant info inside the launcher UI.
- Expose the feature in the sidebar and allow it to be toggled via the existing customizable menu settings for consistency with other account-management tools.

### Description
- Added a new route and page at `/account-management/public-profile` that looks up a player by display name (`findUserByDisplayName`) and calls `QueryPublicProfile` (`getQueryPublicProfile`), then displays a compact results card with key fields (display name, account id, homebase name, commander level, collection-book level, zones completed, total items, last updated) in `src/routes/account-management/public-profile/route.tsx`.
- Added a new sidebar entry and navigation link for the page in `src/components/menu/sidebar.tsx` and wired the corresponding localization key into the sidebar resource files.
- Integrated customizable visibility by adding `publicProfile` to the schema, state relations, and settings UI toggles (`src/lib/validations/schemas/settings.ts`, `src/state/settings/customizable-menu.ts`, and `src/routes/settings/-customizable-menu/-index.tsx`).
- Added localized strings for the new page for all existing locales and registered them in `src/locales/resources.ts`, and updated the generated route tree to include the route so the router resolves the new path (`src/routeTree.gen.ts`).

### Testing
- Ran `npm run lint` and the linter completed successfully (no new lint errors introduced) — success.
- Ran `npx tsc --noEmit`, which failed with pre-existing repository TypeScript errors unrelated to this feature (no new type errors attributable to the added files) — warning/failure (repository-wide issues).
- Started the dev server and captured a page screenshot via Playwright to validate the UI renders; screenshot artifact was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a63f90ed8832aa039f6350c3669c3)